### PR TITLE
Corrige NaN y división por cero en el cálculo del préstamo, y elimina el bypass de ATS en iOS

### DIFF
--- a/App.js
+++ b/App.js
@@ -27,17 +27,29 @@ export default function App() {
     else reset();
   }, [capital, interest, months]);
 
+  const parseNumber = (value) => {
+    if (value === null || value === undefined || value === '') return null;
+    const parsed = parseFloat(String(value).replace(',', '.'));
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
   const calculate = () => {
     reset();
-    if (!capital) {
+    const capitalValue = parseNumber(capital);
+    const interestValue = parseNumber(interest);
+
+    if (capitalValue === null || capitalValue <= 0) {
       setErrorMessage('Añade la cantidad que quieres solicitar');
-    } else if (!interest) {
+    } else if (interestValue === null || interestValue < 0) {
       setErrorMessage('Añade el interes del prestamos');
     } else if (!months) {
       setErrorMessage('Seleccióna los meses a pagar');
     } else {
-      const i = interest / 100;
-      const fee = capital / ((1 - Math.pow(i + 1, -months)) / i);
+      const i = interestValue / 100;
+      const fee =
+        i === 0
+          ? capitalValue / months
+          : capitalValue / ((1 - Math.pow(i + 1, -months)) / i);
       setTotal({
         monthlyFee: fee.toFixed(2).replace('.', ','),
         totalPayable: (fee * months).toFixed(2).replace('.', ','),

--- a/ios/cotizadorprestamos/Info.plist
+++ b/ios/cotizadorprestamos/Info.plist
@@ -26,8 +26,6 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>


### PR DESCRIPTION
Revisión de seguridad y bugs de la calculadora de préstamos.

## Cambios

**🟠 Bug de cálculo — resultados `NaN`**
- `App.js`: `capital` e `interest` son strings crudos del `TextInput` y sólo se comprobaba que fueran *truthy*, nunca que fueran numéricos. Cualquier entrada no numérica (o con coma decimal) llegaba tal cual a la fórmula de anualidad y producía `NaN €` en pantalla. Añadida validación numérica con soporte para coma decimal; se rechaza entrada no numérica o negativa en lugar de mostrar `NaN`.

**🟠 Bug — división por cero**
- `App.js`: con `interest = 0` (el string `"0"` es truthy) resultaba `i = 0`, de modo que `(1-(1+i)^-n)/i` → `0/0` → `NaN`, sin ningún aviso al usuario. Corregido.

**🟡 Configuración iOS**
- `ios/cotizadorprestamos/Info.plist`: `NSAppTransportSecurity → NSAllowsArbitraryLoads = true` desactivaba ATS para **todos** los dominios de la app. El target de tvOS no lo tiene, lo que confirma que era una excepción innecesaria y no un requisito del framework. Eliminado, manteniendo sólo la excepción HTTP para `localhost` que necesita el dev server.

## Revisado sin cambios

- `AndroidManifest.debug.xml` con `usesCleartextTraffic=true`: limitado a la build de debug, requisito estándar del dev server de RN.
- La config de firma de release reutiliza el keystore de debug: es el default sin modificar de la plantilla de RN; cambiarlo requiere saber cómo quieres firmar de verdad.
- No hay API keys ni secretos en el código (no existe ninguna llamada de red en `src/`).

## Pendiente

GitHub reporta 86 alertas de Dependabot. La causa raíz es que RN 0.62.2 / React 16.11.0 son de 2020; corregirlas implica un upgrade mayor de RN que no es verificable sin instalar y compilar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPEv8PeWKJjoR6wvxGNNQc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPEv8PeWKJjoR6wvxGNNQc)_